### PR TITLE
GH-1632 invent default auth header with additional tests

### DIFF
--- a/core/model/src/main/kotlin/au/com/dius/pact/core/model/PactReader.kt
+++ b/core/model/src/main/kotlin/au/com/dius/pact/core/model/PactReader.kt
@@ -117,7 +117,7 @@ fun newHttpClient(baseUrl: String, options: Map<String, Any>): CloseableHttpClie
       when (val auth = options["authentication"] as Auth) {
         is Auth.BasicAuthentication -> basicAuth(baseUrl, auth.username, auth.password, builder)
         is Auth.BearerAuthentication -> {
-          builder.setDefaultHeaders(listOf(BasicHeader("Authorization", "Bearer " + auth.token)))
+          builder.setDefaultHeaders(listOf(BasicHeader(auth.headerName, "Bearer " + auth.token)))
         }
       }
     }

--- a/provider/gradle/README.md
+++ b/provider/gradle/README.md
@@ -756,6 +756,21 @@ pact {
 }
 ```
 
+Customise the authentication header from the default `Authorization` please use `pactBrokerAuthenticationScheme`:
+
+```groovy
+pact {
+
+    serviceProviders {
+        provider1 {
+            hasPactsFromPactBroker('http://pact-broker:5000/', authentication: ['Bearer', pactBrokerToken, 'my-auth-header'])
+        }
+    }
+    
+}
+```
+
+
 Preemptive Authentication can be enabled by setting the `pact.pactbroker.httpclient.usePreemptiveAuthentication` property to `true`.
 
 **NOTE:** If you're using [pactflow.io](https://pactflow.io/), follow these instructions for configuring your [bearer token](https://docs.pactflow.io/docs/getting-started/#configuring-your-api-token).
@@ -860,6 +875,9 @@ pact {
     
         // OR to use a bearer token
         pactBrokerToken = '<TOKEN>'
+        
+        // Customise the authentication header from the default `Authorization`
+        pactBrokerAuthenticationHeader = 'my-auth-header' 
     }
 
 }
@@ -887,6 +905,9 @@ pact {
     publish {
         pactBrokerUrl = 'https://mypactbroker.com'
         pactBrokerToken = 'token'
+     
+        // Customise the authentication header from the default `Authorization`
+        pactBrokerAuthenticationHeader = 'my-auth-header'
     }
 
 }

--- a/provider/gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPlugin.groovy
+++ b/provider/gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPlugin.groovy
@@ -127,7 +127,7 @@ class PactPlugin extends PactPluginBase {
       if (ext.broker.pactBrokerUsername) {
         options.authentication = ['basic', ext.broker.pactBrokerUsername, ext.broker.pactBrokerPassword]
       } else if (ext.broker.pactBrokerToken) {
-        options.authentication = ['bearer', ext.broker.pactBrokerToken]
+        options.authentication = ['bearer', ext.broker.pactBrokerToken, ext.broker.pactBrokerAuthenticationHeader]
       }
       if (provider.brokerConfig.enablePending) {
         options.enablePending = true

--- a/provider/gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPublishTask.groovy
+++ b/provider/gradle/src/main/groovy/au/com/dius/pact/provider/gradle/PactPublishTask.groovy
@@ -62,7 +62,7 @@ abstract class PactPublishTask extends DefaultTask {
         def options = [:]
         if (StringUtils.isNotEmpty(brokerConfig.pactBrokerToken)) {
             options.authentication = [brokerConfig.pactBrokerAuthenticationScheme ?: 'bearer',
-                                      brokerConfig.pactBrokerToken]
+                                      brokerConfig.pactBrokerToken, brokerConfig.pactBrokerAuthenticationHeader]
         }
         else if (StringUtils.isNotEmpty(brokerConfig.pactBrokerUsername)) {
           options.authentication = [brokerConfig.pactBrokerAuthenticationScheme ?: 'basic',

--- a/provider/gradle/src/main/kotlin/au/com/dius/pact/provider/gradle/Broker.kt
+++ b/provider/gradle/src/main/kotlin/au/com/dius/pact/provider/gradle/Broker.kt
@@ -1,5 +1,7 @@
 package au.com.dius.pact.provider.gradle
 
+import au.com.dius.pact.core.support.Auth
+
 /**
  * Config for pact broker
  */
@@ -9,6 +11,7 @@ data class Broker(
   var pactBrokerUsername: String? = null,
   var pactBrokerPassword: String? = null,
   var pactBrokerAuthenticationScheme: String? = null,
+  var pactBrokerAuthenticationHeader: String = Auth.DEFAULT_AUTH_HEADER,
   var retryCountWhileUnknown: Int? = null,
   var retryWhileUnknownInterval: Int? = null
 ) {
@@ -17,6 +20,7 @@ data class Broker(
     return "Broker(pactBrokerUrl=$pactBrokerUrl, pactBrokerToken=$pactBrokerToken, " +
       "pactBrokerUsername=$pactBrokerUsername, pactBrokerPassword=$password, " +
       "pactBrokerAuthenticationScheme=$pactBrokerAuthenticationScheme, " +
+      "pactBrokerAuthenticationHeader=$pactBrokerAuthenticationHeader, " +
       "retryCountWhileUnknown=$retryCountWhileUnknown, retryWhileUnknownInterval=$retryWhileUnknownInterval)"
   }
 }

--- a/provider/gradle/src/main/kotlin/au/com/dius/pact/provider/gradle/PactCanIDeployBaseTask.kt
+++ b/provider/gradle/src/main/kotlin/au/com/dius/pact/provider/gradle/PactCanIDeployBaseTask.kt
@@ -12,7 +12,7 @@ open class PactCanIDeployBaseTask : DefaultTask() {
       val options = mutableMapOf<String, Any>()
       if (brokerConfig.pactBrokerToken.isNotEmpty()) {
         options["authentication"] = listOf(brokerConfig.pactBrokerAuthenticationScheme ?: "bearer",
-          brokerConfig.pactBrokerToken)
+          brokerConfig.pactBrokerToken, brokerConfig.pactBrokerAuthenticationHeader)
       } else if (brokerConfig.pactBrokerUsername.isNotEmpty()) {
         options["authentication"] = listOf(brokerConfig.pactBrokerAuthenticationScheme ?: "basic",
           brokerConfig.pactBrokerUsername, brokerConfig.pactBrokerPassword)

--- a/provider/gradle/src/main/kotlin/au/com/dius/pact/provider/gradle/PactPublish.kt
+++ b/provider/gradle/src/main/kotlin/au/com/dius/pact/provider/gradle/PactPublish.kt
@@ -1,5 +1,7 @@
 package au.com.dius.pact.provider.gradle
 
+import au.com.dius.pact.core.support.Auth.Companion.DEFAULT_AUTH_HEADER
+
 /**
  * Config for pact publish task
  */
@@ -11,6 +13,7 @@ data class PactPublish @JvmOverloads constructor(
   var pactBrokerUsername: String? = null,
   var pactBrokerPassword: String? = null,
   var pactBrokerAuthenticationScheme: String? = null,
+  var pactBrokerAuthenticationHeader: String? = DEFAULT_AUTH_HEADER,
   var tags: List<String> = listOf(),
   var excludes: List<String> = listOf(),
   var consumerBranch: String? = null,
@@ -21,7 +24,8 @@ data class PactPublish @JvmOverloads constructor(
     return "PactPublish(pactDirectory=$pactDirectory, pactBrokerUrl=$pactBrokerUrl, " +
       "consumerVersion=$consumerVersion, pactBrokerToken=$pactBrokerToken, " +
       "pactBrokerUsername=$pactBrokerUsername, pactBrokerPassword=$password, " +
-      "pactBrokerAuthenticationScheme=$pactBrokerAuthenticationScheme, tags=$tags, excludes=$excludes, " +
+      "pactBrokerAuthenticationScheme=$pactBrokerAuthenticationScheme, " +
+      "pactBrokerAuthenticationHeader=$pactBrokerAuthenticationHeader, tags=$tags, excludes=$excludes, " +
       "consumerBranch=$consumerBranch, consumerBuildUrl=$consumerBuildUrl)"
   }
 }

--- a/provider/gradle/src/test/groovy/au/com/dius/pact/provider/gradle/PactPublishTaskSpec.groovy
+++ b/provider/gradle/src/test/groovy/au/com/dius/pact/provider/gradle/PactPublishTaskSpec.groovy
@@ -107,7 +107,26 @@ class PactPublishTaskSpec extends Specification {
     project.tasks.pactPublish.publishPacts()
 
     then:
-    1 * new PactBrokerClient(_, ['authentication': ['bearer', 'token1234']], _) >> brokerClient
+    1 * new PactBrokerClient(_, ['authentication': ['bearer', 'token1234', 'Authorization']], _) >> brokerClient
+    1 * brokerClient.uploadPactFile(_, _) >> new Ok(null)
+  }
+
+  def 'passes in bearer token to the broker client with custom auth header'() {
+    given:
+    project.pact {
+      publish {
+        pactBrokerToken = 'token1234'
+        pactBrokerUrl = 'pactBrokerUrl'
+        pactBrokerAuthenticationHeader = 'custom-header'
+      }
+    }
+    project.evaluate()
+
+    when:
+    project.tasks.pactPublish.publishPacts()
+
+    then:
+    1 * new PactBrokerClient(_, ['authentication': ['bearer', 'token1234', 'custom-header']], _) >> brokerClient
     1 * brokerClient.uploadPactFile(_, _) >> new Ok(null)
   }
 

--- a/provider/junit/README.md
+++ b/provider/junit/README.md
@@ -380,6 +380,12 @@ Bearer tokens are also supported. For example:
   authentication = @PactBrokerAuth(token = "test"))
 ```
 
+Customise the authentication header from the default `Authorization` with `headerName` property of `@PactBrokerAuth`:
+
+```java
+@PactBrokerAuth(token = "test", headerName = "custom-auth-header")
+```
+
 The `token`, `username` and `password` values also take Java system property expressions.
 
 Preemptive Authentication can be enabled by setting the `pact.pactbroker.httpclient.usePreemptiveAuthentication` Java

--- a/provider/maven/README.md
+++ b/provider/maven/README.md
@@ -460,6 +460,8 @@ Here is how you configure the plugin to use bearer token authentication for veri
               <authentication>
                   <scheme>bearer</scheme>
                   <token>TOKEN</token>
+                  <!-- Customise the authentication header from the default `Authorization` -->
+                  <authHeaderName>my-auth-header</authHeaderName>
               </authentication>
           </pactBroker>
         </serviceProvider>
@@ -953,6 +955,16 @@ Or to use a bearer token:
       <pactBrokerUrl>http://pactbroker:1234</pactBrokerUrl>
       <pactBrokerToken>TOKEN</pactBrokerToken> <!-- Replace TOKEN with the actual token -->
       <pactBrokerAuthenticationScheme>Bearer</pactBrokerAuthenticationScheme>
+    </configuration>
+</plugin>
+```
+
+Customise the authentication header from the default `Authorization` please use `pactBrokerAuthenticationScheme`:
+
+```xml
+<plugin>
+    <configuration>
+      <pactBrokerAuthenticationHeader>my-auth-header</pactBrokerAuthenticationHeader>
     </configuration>
 </plugin>
 ```

--- a/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactBaseMojo.kt
+++ b/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactBaseMojo.kt
@@ -1,6 +1,7 @@
 package au.com.dius.pact.provider.maven
 
 import au.com.dius.pact.core.pactbroker.PactBrokerClientConfig
+import au.com.dius.pact.core.support.Auth.Companion.DEFAULT_AUTH_HEADER
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugins.annotations.Component
 import org.apache.maven.plugins.annotations.Parameter
@@ -27,6 +28,9 @@ abstract class PactBaseMojo : AbstractMojo() {
   @Parameter(defaultValue = "basic", property = "pact.broker.authenticationScheme")
   protected var pactBrokerAuthenticationScheme: String? = null
 
+  @Parameter(defaultValue = DEFAULT_AUTH_HEADER, property = "pact.broker.authenticationHeader")
+  protected var pactBrokerAuthenticationHeader: String? = null
+
   @Parameter(defaultValue = "\${settings}", readonly = true)
   protected lateinit var settings: Settings
 
@@ -46,7 +50,7 @@ abstract class PactBaseMojo : AbstractMojo() {
     val options = mutableMapOf<String, Any>()
     if (!pactBrokerToken.isNullOrEmpty()) {
       pactBrokerAuthenticationScheme = "bearer"
-      options["authentication"] = listOf(pactBrokerAuthenticationScheme, pactBrokerToken)
+      options["authentication"] = listOf(pactBrokerAuthenticationScheme, pactBrokerToken, pactBrokerAuthenticationHeader)
     } else if (!pactBrokerUsername.isNullOrEmpty()) {
       options["authentication"] = listOf(pactBrokerAuthenticationScheme ?: "basic", pactBrokerUsername,
         pactBrokerPassword)

--- a/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactBroker.kt
+++ b/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactBroker.kt
@@ -1,6 +1,7 @@
 package au.com.dius.pact.provider.maven
 
 import au.com.dius.pact.core.pactbroker.ConsumerVersionSelectors
+import au.com.dius.pact.core.support.Auth.Companion.DEFAULT_AUTH_HEADER
 import au.com.dius.pact.core.support.json.JsonParser
 import org.apache.maven.plugin.MojoFailureException
 import java.net.URL
@@ -216,6 +217,7 @@ data class PactBroker @JvmOverloads constructor(
 data class PactBrokerAuth @JvmOverloads constructor (
   val scheme: String? = "basic",
   val token: String? = null,
+  val authHeaderName: String? = DEFAULT_AUTH_HEADER,
   val username: String? = null,
   val password: String? = null
 )

--- a/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
+++ b/provider/maven/src/main/kotlin/au/com/dius/pact/provider/maven/PactProviderMojo.kt
@@ -174,7 +174,7 @@ open class PactProviderMojo : PactBaseMojo() {
 
     if (pactBroker?.authentication != null) {
       if ("bearer" == provider.pactBroker?.authentication?.scheme || provider.pactBroker?.authentication?.token != null) {
-        options["authentication"] = listOf("bearer", provider.pactBroker!!.authentication!!.token)
+        options["authentication"] = listOf("bearer", provider.pactBroker!!.authentication!!.token, provider.pactBroker!!.authentication!!.authHeaderName)
       } else if ("basic" == provider.pactBroker?.authentication?.scheme) {
         options["authentication"] = listOf(provider.pactBroker!!.authentication!!.scheme, provider.pactBroker!!.authentication!!.username,
                 provider.pactBroker!!.authentication!!.password)

--- a/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
+++ b/provider/maven/src/test/groovy/au/com/dius/pact/provider/maven/PactProviderMojoSpec.groovy
@@ -69,7 +69,7 @@ class PactProviderMojoSpec extends Specification {
   def 'load pacts from pact broker uses the configured pactBroker basic authentication'() {
     given:
     def provider = Spy(new Provider('TestProvider', null as File, null as URL,
-      new PactBroker(new URL('http://broker:1234'), null, new PactBrokerAuth('basic', null, 'test', 'test'), null)))
+      new PactBroker(new URL('http://broker:1234'), null, new PactBrokerAuth('basic', null, 'Authorization', 'test', 'test'), null)))
     def list = []
     def map = [authentication: ['basic', 'test', 'test']]
 
@@ -86,9 +86,26 @@ class PactProviderMojoSpec extends Specification {
   def 'load pacts from pact broker uses the configured pactBroker bearer authentication'() {
     given:
     def provider = Spy(new Provider('TestProvider', null as File, null as URL,
-      new PactBroker(new URL('http://broker:1234'), null, new PactBrokerAuth('bearer', 'test', null, null), null)))
+      new PactBroker(new URL('http://broker:1234'), null, new PactBrokerAuth('bearer', 'test', 'Authorization', null, null), null)))
     def list = []
-    def map = [authentication: ['bearer', 'test']]
+    def map = [authentication: ['bearer', 'test', 'Authorization']]
+
+    when:
+    mojo.loadPactsFromPactBroker(provider, list, [:])
+
+    then:
+    1 * provider.hasPactsFromPactBrokerWithSelectorsV2(map, 'http://broker:1234', []) >> [
+            new Consumer()
+    ]
+    list
+  }
+
+  def 'load pacts from pact broker uses the configured pactBroker bearer authentication with a custom auth header name'() {
+    given:
+    def provider = Spy(new Provider('TestProvider', null as File, null as URL,
+            new PactBroker(new URL('http://broker:1234'), null, new PactBrokerAuth('bearer', 'test', 'custom-header', null, null), null)))
+    def list = []
+    def map = [authentication: ['bearer', 'test', 'custom-header']]
 
     when:
     mojo.loadPactsFromPactBroker(provider, list, [:])
@@ -104,9 +121,9 @@ class PactProviderMojoSpec extends Specification {
     given:
     def provider = Spy(new Provider('TestProvider', null as File, null as URL,
       new PactBroker(new URL('http://broker:1234'), null,
-        new PactBrokerAuth(null, 'test', null, null), null)))
+        new PactBrokerAuth(null, 'test', 'Authorization', null, null), null)))
     def list = []
-    def map = [authentication: ['bearer', 'test']]
+    def map = [authentication: ['bearer', 'test', 'Authorization']]
 
     when:
     mojo.loadPactsFromPactBroker(provider, list, [:])

--- a/provider/src/main/java/au/com/dius/pact/provider/junitsupport/loader/Authentication.java
+++ b/provider/src/main/java/au/com/dius/pact/provider/junitsupport/loader/Authentication.java
@@ -6,6 +6,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import static au.com.dius.pact.core.support.Auth.DEFAULT_AUTH_HEADER;
+
 /**
  * Defines the authentication scheme to use with URLs
  */
@@ -27,4 +29,9 @@ public @interface Authentication {
    * Token to use for bearer token authentication
    */
   String token() default "";
+
+  /**
+   * Override default `Authorization` header with this value
+   */
+  String headerName() default DEFAULT_AUTH_HEADER;
 }

--- a/provider/src/main/java/au/com/dius/pact/provider/junitsupport/loader/PactBrokerAuth.java
+++ b/provider/src/main/java/au/com/dius/pact/provider/junitsupport/loader/PactBrokerAuth.java
@@ -6,6 +6,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import static au.com.dius.pact.core.support.Auth.DEFAULT_AUTH_HEADER;
+
 /**
  * Defines the authentication scheme to use with the pact broker
  */
@@ -27,4 +29,9 @@ public @interface PactBrokerAuth {
    * Token to use for bearer token authentication
    */
   String token() default "";
+
+  /**
+   * Override default `Authorization` header with this value
+   */
+  String headerName() default DEFAULT_AUTH_HEADER;
 }

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/PactBrokerOptions.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/PactBrokerOptions.kt
@@ -1,6 +1,7 @@
 package au.com.dius.pact.provider
 
 import au.com.dius.pact.core.support.Auth
+import au.com.dius.pact.core.support.Auth.Companion.DEFAULT_AUTH_HEADER
 import java.util.LinkedHashMap
 
 data class PactBrokerOptions @JvmOverloads constructor(
@@ -64,8 +65,10 @@ data class PactBrokerOptions @JvmOverloads constructor(
               } else {
                 Auth.BasicAuthentication(auth[1]?.toString().orEmpty(), "")
               }
-              "bearer" -> {
-                Auth.BearerAuthentication(auth[1]?.toString().orEmpty())
+              "bearer" -> if (auth.size > 2) {
+                Auth.BearerAuthentication(auth[1]?.toString().orEmpty(), auth[2]?.toString().orEmpty())
+              } else {
+                Auth.BearerAuthentication(auth[1]?.toString().orEmpty(), DEFAULT_AUTH_HEADER)
               }
               else -> throw RuntimeException("'${auth[0]}' ia not a valid authentication scheme. Only basic or " +
                 "bearer is supported")

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/junitsupport/loader/PactBrokerLoader.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/junitsupport/loader/PactBrokerLoader.kt
@@ -332,6 +332,7 @@ open class PactBrokerLoader(
     } else {
       val username = ep.parseExpression(authentication!!.username, DataType.RAW, resolver)?.toString()
       val token = ep.parseExpression(authentication!!.token, DataType.RAW, resolver)?.toString()
+      val headerName = ep.parseExpression(authentication!!.headerName, DataType.RAW, resolver)?.toString()
 
       // Check if username is set. If yes, use basic auth.
       if (username.isNotEmpty()) {
@@ -345,7 +346,7 @@ open class PactBrokerLoader(
       // Check if token is set. If yes, use bearer auth.
       } else if (token.isNotEmpty()) {
         logger.debug { "Authentication: Bearer" }
-        options = mapOf("authentication" to listOf("bearer", token))
+        options = mapOf("authentication" to listOf("bearer", token, headerName))
       }
     }
 

--- a/provider/src/main/kotlin/au/com/dius/pact/provider/junitsupport/loader/PactUrlLoader.kt
+++ b/provider/src/main/kotlin/au/com/dius/pact/provider/junitsupport/loader/PactUrlLoader.kt
@@ -19,7 +19,7 @@ open class PactUrlLoader(val urls: Array<String>, val authentication: Auth? = nu
   var resolver: ValueResolver = SystemPropertyResolver
 
   constructor(pactUrl: PactUrl) : this(pactUrl.urls, when {
-    pactUrl.auth.token.isNotEmpty() -> Auth.BearerAuthentication(pactUrl.auth.token)
+    pactUrl.auth.token.isNotEmpty() -> Auth.BearerAuthentication(pactUrl.auth.token, pactUrl.auth.headerName)
     pactUrl.auth.username.isNotEmpty() -> Auth.BasicAuthentication(pactUrl.auth.username,
       pactUrl.auth.password)
     else -> null

--- a/provider/src/test/groovy/au/com/dius/pact/provider/PactBrokerOptionsSpec.groovy
+++ b/provider/src/test/groovy/au/com/dius/pact/provider/PactBrokerOptionsSpec.groovy
@@ -16,13 +16,13 @@ class PactBrokerOptionsSpec extends Specification {
 
     options                                                | result
     [:]                                                    | null
-    [authentication: new Auth.BearerAuthentication('123')] | new Auth.BearerAuthentication('123')
+    [authentication: new Auth.BearerAuthentication('123', 'Authorization')] | new Auth.BearerAuthentication('123', 'Authorization')
     [authentication: ['basic', 'bob']]                     | new Auth.BasicAuthentication('bob', '')
     [authentication: ['BASIC', 'bob']]                     | new Auth.BasicAuthentication('bob', '')
     [authentication: ['BASIC', null]]                      | new Auth.BasicAuthentication('', '')
     [authentication: ['basic', 'bob', '1234']]             | new Auth.BasicAuthentication('bob', '1234')
-    [authentication: ['bearer', '1234']]                   | new Auth.BearerAuthentication('1234')
-    [authentication: ['Bearer', '1234']]                   | new Auth.BearerAuthentication('1234')
+    [authentication: ['bearer', '1234']]                   | new Auth.BearerAuthentication('1234', 'Authorization')
+    [authentication: ['Bearer', '1234', 'custom-header']]  | new Auth.BearerAuthentication('1234', 'custom-header')
   }
 
   @Unroll

--- a/provider/src/test/groovy/au/com/dius/pact/provider/ProviderInfoSpec.groovy
+++ b/provider/src/test/groovy/au/com/dius/pact/provider/ProviderInfoSpec.groovy
@@ -210,7 +210,7 @@ class ProviderInfoSpec extends Specification {
     def result = providerInfo.hasPactsFromPactBrokerWithSelectorsV2(options, url, selectors)
 
     then:
-    providerInfo.pactBrokerClient(_, { it.auth == new Auth.BearerAuthentication('123ABC') }) >> pactBrokerClient
+    providerInfo.pactBrokerClient(_, { it.auth == new Auth.BearerAuthentication('Authorization', '123ABC') }) >> pactBrokerClient
     pactBrokerClient.fetchConsumersWithSelectorsV2('TestProvider', selectors, [], '', false, '') >> new Ok([
       new PactBrokerResult('consumer', '', url, [], [], true, null, true, false, null)
     ])

--- a/provider/src/test/groovy/au/com/dius/pact/provider/junitsupport/loader/PactBrokerLoaderSpec.groovy
+++ b/provider/src/test/groovy/au/com/dius/pact/provider/junitsupport/loader/PactBrokerLoaderSpec.groovy
@@ -928,10 +928,24 @@ class PactBrokerLoaderSpec extends Specification {
             .newPactBrokerClient(new URI('http://localhost'), new SystemPropertyResolver())
 
     then:
-    pactBrokerClient.options == ['authentication': ['bearer', 'token-value']]
+    pactBrokerClient.options == ['authentication': ['bearer', 'token-value', 'Authorization']]
   }
 
-  def 'Auth: Uses bearer auth if token and password are provided'() {
+  def 'Auth: Uses bearer auth if token is provided having a custom auth header'() {
+    given:
+    pactBrokerLoader = {
+      new PactBrokerLoader(PactBrokerAnnotationWithTokenAndCustomHeader.getAnnotation(PactBroker))
+    }
+
+    when:
+    def pactBrokerClient = pactBrokerLoader()
+            .newPactBrokerClient(new URI('http://localhost'), new SystemPropertyResolver())
+
+    then:
+    pactBrokerClient.options == ['authentication': ['bearer', 'token-value', 'custom-auth-header']]
+  }
+
+  def 'Auth: Uses bearer auth if token and custom auth header are provided'() {
     given:
     pactBrokerLoader = {
       new PactBrokerLoader(PactBrokerAnnotationWithPasswordAndToken.getAnnotation(PactBroker))
@@ -942,7 +956,7 @@ class PactBrokerLoaderSpec extends Specification {
             .newPactBrokerClient(new URI('http://localhost'), new SystemPropertyResolver())
 
     then:
-    pactBrokerClient.options == ['authentication': ['bearer', 'token-value']]
+    pactBrokerClient.options == ['authentication': ['bearer', 'token-value', 'Authorization']]
   }
 
   def 'Auth: No auth if neither token nor username is provided'() {
@@ -1554,6 +1568,12 @@ class PactBrokerLoaderSpec extends Specification {
   @PactBroker(host = 'pactbroker.host',
       authentication = @PactBrokerAuth(token = 'token-value'))
   static class PactBrokerAnnotationWithOnlyToken {
+
+  }
+
+  @PactBroker(host = 'pactbroker.host',
+      authentication = @PactBrokerAuth(token = 'token-value', headerName = 'custom-auth-header'))
+  static class PactBrokerAnnotationWithTokenAndCustomHeader {
 
   }
 

--- a/provider/src/test/groovy/au/com/dius/pact/provider/junitsupport/loader/PactUrlLoaderSpec.groovy
+++ b/provider/src/test/groovy/au/com/dius/pact/provider/junitsupport/loader/PactUrlLoaderSpec.groovy
@@ -88,7 +88,7 @@ class PactUrlLoaderSpec extends Specification {
     def pacts = loader.load('bob')
 
     then:
-    loader.pactReader.loadPact(new UrlSource('http://localhost:1234'), [authentication: new Auth.BearerAuthentication('1234abcd')]) >> pact1
+    loader.pactReader.loadPact(new UrlSource('http://localhost:1234'), [authentication: new Auth.BearerAuthentication('1234abcd', 'Authorization')]) >> pact1
     pacts == [pact1]
   }
 
@@ -104,7 +104,7 @@ class PactUrlLoaderSpec extends Specification {
     def pacts = loader.load('bob')
 
     then:
-    loader.pactReader.loadPact(new UrlSource('http://localhost:1234'), [authentication: new Auth.BearerAuthentication('1234567890')]) >> pact1
+    loader.pactReader.loadPact(new UrlSource('http://localhost:1234'), [authentication: new Auth.BearerAuthentication('1234567890', 'Authorization')]) >> pact1
     pacts == [pact1]
   }
 }


### PR DESCRIPTION
Having pact broker located behind a custom auth layer with a custom header but `Authorizatrion` it is not possible to access the broker, the PR is proposal to customize it